### PR TITLE
Code Climate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+languages:
+  Ruby: false
+  JavaScript: true
+  PHP: true
+  Python: false
+exclude_paths:
+  - "public/js/bootstrap.js"


### PR DESCRIPTION
Exclude bootstrap.js from Code Climate analysis.
